### PR TITLE
Bug fix + Update to Swift 5, Xcode 12.5, and iOS 12.3.

### DIFF
--- a/BrightnessToggle.podspec
+++ b/BrightnessToggle.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.name = "BrightnessToggle"
   s.summary = "BrightnessToggle lets you toggle between maximum screen brightness and back."
   s.requires_arc = true
-  s.version = "0.5.0"
+  s.version = "0.5.1"
   s.license = { :type => "MIT", :file => "LICENSE" }
   s.author = { "Lammert Westerhoff" => "lwesterhoff@xebia.com" }
   s.homepage = "https://github.com/lammertw/BrightnessToggle"

--- a/BrightnessToggle.podspec
+++ b/BrightnessToggle.podspec
@@ -1,14 +1,14 @@
 Pod::Spec.new do |s|
   s.platform = :ios
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '12.3'
   s.name = "BrightnessToggle"
   s.summary = "BrightnessToggle lets you toggle between maximum screen brightness and back."
   s.requires_arc = true
-  s.version = "0.3.0"
+  s.version = "0.5.0"
   s.license = { :type => "MIT", :file => "LICENSE" }
   s.author = { "Lammert Westerhoff" => "lwesterhoff@xebia.com" }
   s.homepage = "https://github.com/lammertw/BrightnessToggle"
-  s.source = { :git => "https://github.com/lammertw/BrightnessToggle.git", :tag => "0.3.0"}
+  s.source = { :git => "https://github.com/lammertw/BrightnessToggle.git", :tag => "0.5.0"}
   s.framework = "UIKit"
   s.source_files = "BrightnessToggle/**/*.{swift}"
 end

--- a/BrightnessToggle.xcodeproj/project.pbxproj
+++ b/BrightnessToggle.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -103,10 +103,11 @@
 				};
 			};
 			buildConfigurationList = 2F77A0AE1C63437800B0598C /* Build configuration list for PBXProject "BrightnessToggle" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 2F77A0AA1C63437800B0598C;
@@ -178,7 +179,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -220,7 +221,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -240,12 +241,16 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = BrightnessToggle/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = BrightnessToggle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -259,11 +264,15 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = BrightnessToggle/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = BrightnessToggle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/BrightnessToggle.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BrightnessToggle.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BrightnessToggle/BrightnessToggle.swift
+++ b/BrightnessToggle/BrightnessToggle.swift
@@ -13,18 +13,20 @@ public var setToMax: Bool { brightness != nil }
 
 public var enabled = true
 
+private func internalMaxBrightness() {
+    UIScreen.main.brightness = 1
+}
+
 public func maxBrightness() {
-    if enabled {
+    if enabled && !setToMax {
         brightness = UIScreen.main.brightness
-        UIScreen.main.brightness = 1
+        internalMaxBrightness()
     }
 }
 
 private func internalRestoreBrightness() {
-    if enabled {
-        if let brightness = brightness {
-            UIScreen.main.brightness = brightness
-        }
+    if let brightness = brightness {
+        UIScreen.main.brightness = brightness
     }
 }
 
@@ -36,11 +38,13 @@ public func restoreBrightness() {
 }
 
 public func applicationWillResignActive() {
-    internalRestoreBrightness()
+    if enabled {
+        internalRestoreBrightness()
+    }
 }
 
 public func applicationWillEnterForeground() {
-    if setToMax {
-        maxBrightness()
+    if enabled && setToMax {
+        internalMaxBrightness()
     }
 }

--- a/BrightnessToggle/BrightnessToggle.swift
+++ b/BrightnessToggle/BrightnessToggle.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 private var brightness: CGFloat?
-private var setToMax = false
+public var setToMax: Bool { brightness != nil }
 
 public var enabled = true
 
@@ -17,7 +17,6 @@ public func maxBrightness() {
     if enabled {
         brightness = UIScreen.main.brightness
         UIScreen.main.brightness = 1
-        setToMax = true
     }
 }
 
@@ -33,7 +32,6 @@ public func restoreBrightness() {
     if enabled {
         internalRestoreBrightness()
         brightness = nil
-        setToMax = false
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ BrightnessToggle lets you toggle between maximum screen brightness and back on i
 
 ## Requirements
 
-- Swift 2.0
-- iOS 8.0+ / Mac OS X 10.9+ / tvOS 9.0+ / watchOS 2.0+
-- Xcode 7.2+
+- Swift 5.0
+- iOS 12.3+ / Mac OS X 10.9+ / tvOS 9.0+ / watchOS 2.0+
+- Xcode 12.0+
 
 ## Installation
 
-> **Embedded frameworks require a minimum deployment target of iOS 8 or OS X Mavericks (10.9).**
+> **Embedded frameworks require a minimum deployment target of iOS 12.3 or OS X Mavericks (10.9).**
 
 ### CocoaPods
 
@@ -28,7 +28,7 @@ To integrate BrightnessToggle into your Xcode project using CocoaPods, specify i
 
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '12.3'
 use_frameworks!
 
 pod 'BrightnessToggle'
@@ -62,11 +62,11 @@ BrightnessToggle.restoreBrightness()
 Include the following code in your `AppDelegate` to automatically restore brightness when the user leaves the app and set it again to maximum brightness when the app becomes active again (if it was at a maximum when the app became inactive):
 
 ```swift
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         BrightnessToggle.applicationWillResignActive()
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         BrightnessToggle.applicationWillEnterForeground()
     }
 ```


### PR DESCRIPTION
## Swift / Xcode
Apple says:

> Starting April 26, 2021, all iPhone and iPad apps submitted to the App Store must be built with Xcode 12 and the iOS 14 SDK or later.

https://developer.apple.com/news/?id=ib31uj1j

So if you haven't submitted your app already, you need to take this change.

## iOS Target
I picked iOS 12.3 as the minimum deployment target because Xcode 12.5 gives build warnings if your Pod targets anything older.
* Technically, Xcode 12 can target iOS 9, but nobody is releasing new apps for the iPhone 5.
* The iPhone 6 is running iOS 12.5.3 nowadays.

## Bug fix
If you called maxBrightness() multiple times, you would lose the record of the screen's original brightness. I fixed that bug and also let callers see whether we are already at multiple brightness.